### PR TITLE
add gh action to auto update aur package

### DIFF
--- a/.github/workflows/aur.yaml
+++ b/.github/workflows/aur.yaml
@@ -1,0 +1,67 @@
+name: AUR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: aur-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish - ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [mihomosh, mihomosh-bin]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set version
+        env:
+          TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: echo "PKGVER=${TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Update PKGBUILD and .SRCINFO
+        uses: heyhusen/archlinux-package-action@v3.0.0
+        with:
+          path: aur/${{ matrix.package }}
+          pkgver: ${{ env.PKGVER }}
+          updpkgsums: true
+          srcinfo: true
+          namcap: false
+          flags: ''
+
+      - name: Configure SSH for AUR
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+
+      - name: Publish to AUR
+        env:
+          AUR_REPO: ssh://aur@aur.archlinux.org/${{ matrix.package }}.git
+        run: |
+          set -euo pipefail
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
+
+          tmpdir="$(mktemp -d)"
+          git clone "$AUR_REPO" "$tmpdir"
+          cp "aur/${{ matrix.package }}/PKGBUILD" "$tmpdir/PKGBUILD"
+          cp "aur/${{ matrix.package }}/.SRCINFO" "$tmpdir/.SRCINFO"
+
+          cd "$tmpdir"
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add PKGBUILD .SRCINFO
+            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
+              commit -m "Update to v${PKGVER}"
+            git push
+          else
+            echo "No changes to publish."
+          fi

--- a/aur/mihomosh-bin/PKGBUILD
+++ b/aur/mihomosh-bin/PKGBUILD
@@ -13,6 +13,7 @@ source=(
   "${pkgname}-${pkgver}.tar.gz::https://github.com/SamuNatsu/mihomosh/releases/download/v${pkgver}/mihomosh-Linux-musl-x86_64.tar.gz"
   "LICENSE::https://raw.githubusercontent.com/SamuNatsu/mihomosh/v${pkgver}/LICENSE"
 )
+# CI workflow's updpkgsums: true does it automatically.
 sha256sums=('SKIP' 'SKIP')
 
 package() {

--- a/aur/mihomosh-bin/PKGBUILD
+++ b/aur/mihomosh-bin/PKGBUILD
@@ -1,0 +1,21 @@
+# Maintainer: k88936 email: kvtodev@outlook.com
+
+pkgname=mihomosh-bin
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="A CLI Toolkit for Mihomo (prebuilt binary)"
+arch=('x86_64')
+url="https://github.com/SamuNatsu/mihomosh"
+license=('GPL3')
+provides=('mihomosh')
+conflicts=('mihomosh')
+source=(
+  "${pkgname}-${pkgver}.tar.gz::https://github.com/SamuNatsu/mihomosh/releases/download/v${pkgver}/mihomosh-Linux-musl-x86_64.tar.gz"
+  "LICENSE::https://raw.githubusercontent.com/SamuNatsu/mihomosh/v${pkgver}/LICENSE"
+)
+sha256sums=('SKIP' 'SKIP')
+
+package() {
+  install -Dm755 "${srcdir}/mihomosh" "${pkgdir}/usr/bin/mihomosh"
+  install -Dm644 "${srcdir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/aur/mihomosh/PKGBUILD
+++ b/aur/mihomosh/PKGBUILD
@@ -8,6 +8,8 @@ arch=('x86_64')
 url="https://github.com/SamuNatsu/mihomosh"
 license=('GPL3')
 options=(!lto)
+provides=('mihomosh')
+conflicts=('mihomosh-bin')
 makedepends=('cargo' 'rust' 'base-devel' 'pkg-config')
 source=("git+https://github.com/SamuNatsu/mihomosh.git#tag=v${pkgver}")
 sha256sums=('SKIP')

--- a/aur/mihomosh/PKGBUILD
+++ b/aur/mihomosh/PKGBUILD
@@ -7,7 +7,6 @@ pkgdesc="A CLI Toolkit for Mihomo"
 arch=('x86_64')
 url="https://github.com/SamuNatsu/mihomosh"
 license=('GPL3')
-depends=('openssl')
 options=(!lto)
 makedepends=('cargo' 'rust' 'base-devel' 'pkg-config')
 source=("git+https://github.com/SamuNatsu/mihomosh.git#tag=v${pkgver}")

--- a/aur/mihomosh/PKGBUILD
+++ b/aur/mihomosh/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: k88936 email: kvtodev@outlook.com
+
+pkgname=mihomosh
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="A CLI Toolkit for Mihomo"
+arch=('x86_64')
+url="https://github.com/SamuNatsu/mihomosh"
+license=('GPL3')
+depends=('openssl')
+options=(!lto)
+makedepends=('cargo' 'rust' 'base-devel' 'pkg-config')
+source=("git+https://github.com/SamuNatsu/mihomosh.git#tag=v${pkgver}")
+sha256sums=('SKIP')
+
+build() {
+  cd "${srcdir}/${pkgname}"
+  export CARGO_PROFILE_RELEASE_LTO=false
+  cargo build --profile release --locked
+}
+
+package() {
+  cd "${srcdir}/${pkgname}"
+  install -Dm755 "target/release/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+
+  # Install license
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
this includes both mihomosh (from src ) and mihomosh-bin (from gh release prebuilt)

I [tested](https://github.com/k88936/mihomosh/actions/runs/26650001052)  this on my fork, and it updated current versions on aur to v2.3.2.

additionaly, it requires ssh secret for aur to upload to repo secrect (AUR_SSH_PRIVATE_KEY) I think the best way is upload [yours](https://wiki.archlinux.org/title/AUR_submission_guidelines#Authentication)  after inviting your account as co-maintainer