### PR TITLE
Network config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "url",
  "urlencoding",
  "wildcard",
+ "winreg",
 ]
 
 [[package]]
@@ -2984,6 +2985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
  "boa_engine",
  "boa_runtime",
  "bytes",
+ "cfg-if",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ unicode-width = "0.2.1"
 url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1.3"
 wildcard = "0.3.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.56.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ boa_engine = "0.20.0"
 boa_runtime = "0.20.0"
 bytes = "1.10.1"
 chrono = "0.4.41"
+cfg-if = "1"
 clap = { version = "4.5.40", features = ["derive"] }
 clap_complete = "4.5.54"
 console = "0.16.0"

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -164,6 +164,9 @@ $ mihomosh proxy update
 
 ### 系统代理开关(beta)
 
+> [!CAUTION]
+> 目前仅对shell环境支持较好，Windows的桌面应用在重启应用后生效。Linux和MacOS的桌面环境较为混乱，暂时未做支持。
+
 目前支持Linux、Windows和MacOS的系统代理开关。
 
 windows可以直接使用命令，代理会写入系统设置
@@ -174,8 +177,6 @@ $ mihomosh network proxy
 
 Linux和MacOS下运行以上命令会在配置文件夹内生成.sh/.fish/.elv文件，请在需要的.bashrc内根据shell类型引用对应的脚本。比如默认的bash环境添加
 
-> [!CAUTION]
-> 该方法仅对shell环境生效，Linux和MacOS的桌面环境较为混乱，对于桌面环境建议使用GUI软件。
 
 ```sh
 # Set shell proxy (Provided by Mihomosh)

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -161,3 +161,15 @@ eval "$(mihomosh shell-completion bash)"
 ```sh
 $ mihomosh proxy update
 ```
+
+### 系统代理开关(beta)
+
+目前支持Linux和Windows的系统代理开关
+
+windows可以直接使用
+
+```sh
+$ mihomosh network proxy
+```
+
+Linux下运行以上命令会在配置文件夹内生成.sh/.fish/.elv文件，请在需要的.bashrc或其他与执行文件内根据shell类型引用对应的脚本

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -164,12 +164,20 @@ $ mihomosh proxy update
 
 ### 系统代理开关(beta)
 
-目前支持Linux和Windows的系统代理开关
+目前支持Linux、Windows和MacOS的系统代理开关。
 
-windows可以直接使用
+windows可以直接使用命令，代理会写入系统设置
 
 ```sh
 $ mihomosh network proxy
 ```
 
-Linux下运行以上命令会在配置文件夹内生成.sh/.fish/.elv文件，请在需要的.bashrc或其他与执行文件内根据shell类型引用对应的脚本
+Linux和MacOS下运行以上命令会在配置文件夹内生成.sh/.fish/.elv文件，请在需要的.bashrc内根据shell类型引用对应的脚本。比如默认的bash环境添加
+
+> [!CAUTION]
+> 该方法仅对shell环境生效，Linux和MacOS的桌面环境较为混乱，对于桌面环境建议使用GUI软件。
+
+```sh
+# Set shell proxy (Provided by Mihomosh)
+source <配置文件地址>/proxy.sh
+```

--- a/src/arguments/mod.rs
+++ b/src/arguments/mod.rs
@@ -5,13 +5,14 @@ pub mod inspect;
 pub mod profile;
 pub mod proxy;
 pub mod rule_set;
+pub mod network;
 
 use clap::Parser;
 use clap_complete::Shell;
 
 use crate::arguments::{
     config::ConfigArgs, connection::ConnectionArgs, control::ControlArgs, inspect::InspectArgs,
-    profile::ProfileArgs, proxy::ProxyArgs, rule_set::RuleSetArgs,
+    profile::ProfileArgs, proxy::ProxyArgs, rule_set::RuleSetArgs, network::NetworkArgs,
 };
 
 /// A Command Line Interface for Mihomo
@@ -48,6 +49,10 @@ pub enum Args {
     /// Print/Update rule sets
     #[command(subcommand)]
     RuleSet(RuleSetArgs),
+
+    /// Manage system network
+    #[command(subcommand)]
+    Network(NetworkArgs),
 
     /// Generate shell completion
     ShellCompletion {

--- a/src/arguments/network.rs
+++ b/src/arguments/network.rs
@@ -1,0 +1,21 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum NetworkArgs {
+    /// Print System Network Configuration
+    View,
+
+    /// Set System Proxy Environment Variables
+    Proxy,
+
+    /// Clear System Proxy Environment Variables
+    UnProxy,
+
+/* 待开发
+    /// Enable Tun Mode 
+    Tun,
+
+    /// Disable Tun Mode
+    UnTun,
+*/
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod connection;
 pub mod control;
 pub mod inspect;
+pub mod network;
 pub mod profile;
 pub mod proxy;
 pub mod rule;

--- a/src/commands/network/mod.rs
+++ b/src/commands/network/mod.rs
@@ -1,0 +1,52 @@
+mod sys_proxy;
+
+use anyhow::{Context, Result};
+use crate::{
+    arguments::network::NetworkArgs,
+    models::config::Config,
+    println_secondary, println_success,
+};
+
+use sys_proxy::{SysProxyManager, SysProxyStatus};
+
+pub async fn handle_network(args: NetworkArgs) -> Result<()> {
+    match args {
+        NetworkArgs::View => view().await?,
+        NetworkArgs::Proxy => set_proxy().await?,
+        NetworkArgs::UnProxy => clear_proxy().await?,
+    }
+    Ok(())
+}
+
+async fn view() -> Result<()> {
+    let status = SysProxyManager::get()?;
+    if status.enabled {
+        println_success!(
+            "System proxy is ON (port: {})",
+            status.proxy_port.unwrap_or(0)
+        );
+    } else {
+        println_secondary!("System proxy is OFF");
+    }
+    Ok(())
+}
+
+async fn set_proxy() -> Result<()> {
+    let cfg = Config::get_instance();
+    let port = cfg.mixed_port.or(cfg.port).unwrap_or(7890);
+
+    SysProxyManager::set(SysProxyStatus {
+        enabled: true,
+        proxy_port: Some(port),
+    })
+    .context("Fail to set system proxy")?;
+
+    println_success!("System proxy enabled on port {port}");
+    Ok(())
+}
+
+async fn clear_proxy() -> Result<()> {
+    SysProxyManager::clear().context("Fail to clear system proxy")?;
+    println_success!("System proxy disabled");
+    Ok(())
+}

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use crate::utils::dir;
+use crate::{
+    utils::dir,
+    println_secondary,
+};
 use super::SysProxyStatus;
 
 pub struct PlatformProxy;
@@ -21,7 +24,8 @@ impl PlatformProxy {
     /// 生成代理脚本文件，用户 source 后即可启用代理
     pub fn set(status: SysProxyStatus) -> Result<()> {
         let proxy_port = status.proxy_port.unwrap_or(7890);
-        write_scripts(proxy_port, proxy_port)
+        write_scripts(proxy_port, proxy_port);
+        println_secondary!("Manually source the script to enable proxy. path:{dir::get_data_dir().display()}");
     }
 
     /// 清空脚本文件，用户 source 后无任何效果

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -1,0 +1,130 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::utils::dir;
+use super::SysProxyStatus;
+
+pub struct PlatformProxy;
+
+impl PlatformProxy {
+    /// 读取当前 shell 的代理环境变量（只读，无需 unsafe）
+    pub fn get() -> Result<SysProxyStatus> {
+        let http = std::env::var("http_proxy").ok()
+            .or_else(|| std::env::var("HTTP_PROXY").ok());
+        let enabled = http.is_some();
+        let proxy_port = http.and_then(|v| parse_port(&v));
+        Ok(SysProxyStatus { enabled, proxy_port })
+    }
+
+    /// 生成代理脚本文件，用户 source 后即可启用代理
+    pub fn set(status: SysProxyStatus) -> Result<()> {
+        let proxy_port = status.proxy_port.unwrap_or(7890);
+        write_scripts(proxy_port, proxy_port)
+    }
+
+    /// 清空脚本文件，用户 source 后无任何效果
+    pub fn clear() -> Result<()> {
+        clear_scripts()
+    }
+}
+
+// ── 脚本文件路径 ──
+
+fn script_paths() -> [PathBuf; 3] {
+    let dir = dir::get_data_dir().to_owned();
+    [
+        dir.join("proxy.sh"),
+        dir.join("proxy.fish"),
+        dir.join("proxy.elv"),
+    ]
+}
+
+fn write_scripts(http_port: u16, https_port: u16) -> Result<()> {
+    let [sh, fish, elv] = script_paths();
+
+    fs::write(&sh, bash_script(http_port, https_port))
+        .with_context(|| format!("Fail to write `{}`", sh.display()))?;
+    fs::write(&fish, fish_script(http_port, https_port))
+        .with_context(|| format!("Fail to write `{}`", fish.display()))?;
+    fs::write(&elv, elvish_script(http_port, https_port))
+        .with_context(|| format!("Fail to write `{}`", elv.display()))?;
+
+    Ok(())
+}
+
+fn clear_scripts() -> Result<()> {
+    let [sh, fish, elv] = script_paths();
+    let empty = "# Mihomo proxy is OFF\n";
+
+    for path in [sh, fish, elv] {
+        fs::write(&path, empty)
+            .with_context(|| format!("Fail to write `{}`", path.display()))?;
+    }
+
+    Ok(())
+}
+
+// ── 工具函数 ──
+
+fn parse_port(url: &str) -> Option<u16> {
+    url.rsplit(':').next()?.parse().ok()
+}
+
+// ── 脚本模板 ──
+
+fn bash_script(http_port: u16, https_port: u16) -> String {
+    format!(
+r#"#!/bin/sh
+# Mihomo proxy environment setup for bash/zsh
+# Add to your ~/.bashrc or ~/.zshrc:
+#   . ~/.local/share/mihomosh/proxy.sh
+
+export http_proxy="http://127.0.0.1:{http_port}"
+export https_proxy="http://127.0.0.1:{https_port}"
+export HTTP_PROXY="$http_proxy"
+export HTTPS_PROXY="$https_proxy"
+export all_proxy="socks5h://127.0.0.1:{http_port}"
+export ALL_PROXY="$all_proxy"
+export no_proxy="localhost,127.0.0.1,::1"
+export NO_PROXY="$no_proxy"
+"#
+    )
+}
+
+fn fish_script(http_port: u16, https_port: u16) -> String {
+    format!(
+r#"# Mihomo proxy environment setup for fish
+# Add to your ~/.config/fish/config.fish:
+#   source ~/.local/share/mihomosh/proxy.fish
+
+set -gx http_proxy "http://127.0.0.1:{http_port}"
+set -gx https_proxy "http://127.0.0.1:{https_port}"
+set -gx HTTP_PROXY $http_proxy
+set -gx HTTPS_PROXY $https_proxy
+set -gx all_proxy "socks5h://127.0.0.1:{http_port}"
+set -gx ALL_PROXY $all_proxy
+set -gx no_proxy "localhost,127.0.0.1,::1"
+set -gx NO_PROXY $no_proxy
+"#
+    )
+}
+
+fn elvish_script(http_port: u16, https_port: u16) -> String {
+    format!(
+r#"# Mihomo proxy environment setup for elvish
+# Add to your ~/.elvish/rc.elv:
+#   eval (slurp < ~/.local/share/mihomosh/proxy.elv)
+
+set E:http_proxy = "http://127.0.0.1:{http_port}"
+set E:https_proxy = "http://127.0.0.1:{https_port}"
+set E:HTTP_PROXY = $E:http_proxy
+set E:HTTPS_PROXY = $E:https_proxy
+set E:all_proxy = "socks5h://127.0.0.1:{http_port}"
+set E:ALL_PROXY = $E:all_proxy
+set E:no_proxy = "localhost,127.0.0.1,::1"
+set E:NO_PROXY = $E:no_proxy
+"#
+    )
+}

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 
 use crate::{
     utils::dir,
-    println_secondary,
+    println_warn
 };
 use super::SysProxyStatus;
 
@@ -24,8 +24,9 @@ impl PlatformProxy {
     /// 生成代理脚本文件，用户 source 后即可启用代理
     pub fn set(status: SysProxyStatus) -> Result<()> {
         let proxy_port = status.proxy_port.unwrap_or(7890);
-        write_scripts(proxy_port, proxy_port);
-        println_secondary!("Manually source the script to enable proxy. path:{dir::get_data_dir().display()}");
+        let result = write_scripts(proxy_port, proxy_port);
+        println_warn!("Manually source the script to enable proxy. path:{}", dir::get_data_dir().display());
+        result
     }
 
     /// 清空脚本文件，用户 source 后无任何效果

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -25,7 +25,7 @@ impl PlatformProxy {
     pub fn set(status: SysProxyStatus) -> Result<()> {
         let proxy_port = status.proxy_port.unwrap_or(7890);
         let result = write_scripts(proxy_port, proxy_port);
-        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}/proxy.sh", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file. Script path: {}/proxy.sh", dir::get_data_dir().display());
         result
     }
 

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -25,7 +25,7 @@ impl PlatformProxy {
     pub fn set(status: SysProxyStatus) -> Result<()> {
         let proxy_port = status.proxy_port.unwrap_or(7890);
         let result = write_scripts(proxy_port, proxy_port);
-        println_warn!("Manually source the script to enable proxy. path:{}", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}.sh", dir::get_data_dir().display());
         result
     }
 

--- a/src/commands/network/sys_proxy/linux.rs
+++ b/src/commands/network/sys_proxy/linux.rs
@@ -25,7 +25,7 @@ impl PlatformProxy {
     pub fn set(status: SysProxyStatus) -> Result<()> {
         let proxy_port = status.proxy_port.unwrap_or(7890);
         let result = write_scripts(proxy_port, proxy_port);
-        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}.sh", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}/proxy.sh", dir::get_data_dir().display());
         result
     }
 

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -45,12 +45,13 @@ impl PlatformProxy {
             .unwrap_or(7890);
 
 
-        write_scripts(
+        let result = write_scripts(
             port,
             port,
         );
 
-        println_warn!("Manually source the script to enable proxy. path:{}", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}.sh", dir::get_data_dir().display());
+        result
     }
 
 

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -50,7 +50,7 @@ impl PlatformProxy {
             port,
         );
 
-        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}.sh", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}/proxy.sh", dir::get_data_dir().display());
         result
     }
 

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -50,7 +50,7 @@ impl PlatformProxy {
             port,
         );
 
-        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file >{}/proxy.sh", dir::get_data_dir().display());
+        println_warn!("Manually source the script to enable proxy or add it to your .bashrc file. Script path: {}/proxy.sh", dir::get_data_dir().display());
         result
     }
 

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use crate::utils::dir;
+use crate::{
+    utils::dir,
+    println_secondary,
+};
 
 use super::SysProxyStatus;
 
@@ -45,7 +48,9 @@ impl PlatformProxy {
         write_scripts(
             port,
             port,
-        )
+        );
+
+        println_secondary!("Manually source the script to enable proxy. path:{dir::get_data_dir().display()}");
     }
 
 

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -1,0 +1,284 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::utils::dir;
+
+use super::SysProxyStatus;
+
+
+pub struct PlatformProxy;
+
+
+impl PlatformProxy {
+    pub fn get() -> Result<SysProxyStatus> {
+
+        let http = std::env::var("http_proxy")
+            .ok()
+            .or_else(|| {
+                std::env::var("HTTP_PROXY").ok()
+            });
+
+
+        let enabled = http.is_some();
+
+
+        let proxy_port = http
+            .and_then(|v| parse_port(&v));
+
+
+        Ok(SysProxyStatus {
+            enabled,
+            proxy_port,
+        })
+    }
+
+
+    pub fn set(status: SysProxyStatus) -> Result<()> {
+
+        let port = status
+            .proxy_port
+            .unwrap_or(7890);
+
+
+        write_scripts(
+            port,
+            port,
+        )
+    }
+
+
+
+    /// 清空代理脚本
+    pub fn clear() -> Result<()> {
+
+        clear_scripts()
+    }
+}
+
+
+
+// =======================
+// 文件路径
+// =======================
+
+
+fn script_paths() -> [PathBuf; 3] {
+
+    let dir = dir::get_data_dir()
+        .to_owned();
+
+
+    [
+        dir.join("proxy.sh"),
+        dir.join("proxy.fish"),
+        dir.join("proxy.elv"),
+    ]
+}
+
+
+
+// =======================
+// 写入脚本
+// =======================
+
+
+fn write_scripts(
+    http_port: u16,
+    https_port: u16,
+) -> Result<()> {
+
+    let [sh, fish, elv] = script_paths();
+
+
+    fs::write(
+        &sh,
+        bash_script(
+            http_port,
+            https_port,
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "Fail to write `{}`",
+            sh.display()
+        )
+    })?;
+
+
+    fs::write(
+        &fish,
+        fish_script(
+            http_port,
+            https_port,
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "Fail to write `{}`",
+            fish.display()
+        )
+    })?;
+
+
+    fs::write(
+        &elv,
+        elvish_script(
+            http_port,
+            https_port,
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "Fail to write `{}`",
+            elv.display()
+        )
+    })?;
+
+
+    Ok(())
+}
+
+
+
+fn clear_scripts() -> Result<()> {
+
+    let [sh, fish, elv] = script_paths();
+
+
+    let empty =
+        "# Mihomo proxy is OFF\n";
+
+
+    for path in [sh, fish, elv] {
+
+        fs::write(
+            &path,
+            empty,
+        )
+        .with_context(|| {
+            format!(
+                "Fail to write `{}`",
+                path.display()
+            )
+        })?;
+    }
+
+
+    Ok(())
+}
+
+
+
+// =======================
+// 工具函数
+// =======================
+
+
+fn parse_port(url: &str) -> Option<u16> {
+
+    url.rsplit(':')
+        .next()?
+        .parse()
+        .ok()
+}
+
+
+
+// =======================
+// Shell脚本模板
+// =======================
+
+
+fn bash_script(
+    http_port: u16,
+    https_port: u16,
+) -> String {
+
+    format!(
+r#"#!/bin/sh
+# Mihomo proxy environment setup for macOS bash/zsh
+#
+# Enable:
+#   source ~/.local/share/mihomosh/proxy.sh
+
+
+export http_proxy="http://127.0.0.1:{http_port}"
+export https_proxy="http://127.0.0.1:{https_port}"
+
+export HTTP_PROXY="$http_proxy"
+export HTTPS_PROXY="$https_proxy"
+
+
+export all_proxy="socks5h://127.0.0.1:{http_port}"
+export ALL_PROXY="$all_proxy"
+
+
+export no_proxy="localhost,127.0.0.1,::1"
+export NO_PROXY="$no_proxy"
+"#
+    )
+}
+
+
+
+fn fish_script(
+    http_port: u16,
+    https_port: u16,
+) -> String {
+
+    format!(
+r#"# Mihomo proxy environment setup for fish
+#
+# Enable:
+#   source ~/.local/share/mihomosh/proxy.fish
+
+
+set -gx http_proxy "http://127.0.0.1:{http_port}"
+set -gx https_proxy "http://127.0.0.1:{https_port}"
+
+set -gx HTTP_PROXY $http_proxy
+set -gx HTTPS_PROXY $https_proxy
+
+
+set -gx all_proxy "socks5h://127.0.0.1:{http_port}"
+set -gx ALL_PROXY $all_proxy
+
+
+set -gx no_proxy "localhost,127.0.0.1,::1"
+set -gx NO_PROXY $no_proxy
+"#
+    )
+}
+
+
+
+fn elvish_script(
+    http_port: u16,
+    https_port: u16,
+) -> String {
+
+    format!(
+r#"# Mihomo proxy environment setup for elvish
+#
+# Enable:
+#   eval (slurp < ~/.local/share/mihomosh/proxy.elv)
+
+
+set E:http_proxy "http://127.0.0.1:{http_port}"
+set E:https_proxy "http://127.0.0.1:{https_port}"
+
+set E:HTTP_PROXY $E:http_proxy
+set E:HTTPS_PROXY $E:https_proxy
+
+
+set E:all_proxy "socks5h://127.0.0.1:{http_port}"
+set E:ALL_PROXY $E:all_proxy
+
+
+set E:no_proxy "localhost,127.0.0.1,::1"
+set E:NO_PROXY $E:no_proxy
+"#
+    )
+}

--- a/src/commands/network/sys_proxy/macos.rs
+++ b/src/commands/network/sys_proxy/macos.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 
 use crate::{
     utils::dir,
-    println_secondary,
+    println_warn,
 };
 
 use super::SysProxyStatus;
@@ -50,7 +50,7 @@ impl PlatformProxy {
             port,
         );
 
-        println_secondary!("Manually source the script to enable proxy. path:{dir::get_data_dir().display()}");
+        println_warn!("Manually source the script to enable proxy. path:{}", dir::get_data_dir().display());
     }
 
 

--- a/src/commands/network/sys_proxy/mod.rs
+++ b/src/commands/network/sys_proxy/mod.rs
@@ -5,14 +5,18 @@ pub struct SysProxyStatus {
     pub proxy_port: Option<u16>,
 }
 
-#[cfg(target_os = "windows")]
-mod windows;
-#[cfg(target_os = "windows")]
-use windows::PlatformProxy;
-#[cfg(target_os = "linux")]
-mod linux;
-#[cfg(target_os = "linux")]
-use linux::PlatformProxy;
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "windows")] {
+        mod windows;
+        use windows::PlatformProxy;
+    } else if #[cfg(target_os = "linux")] {
+        mod linux;
+        use linux::PlatformProxy;
+    } else {
+        mod unsupported;
+        use unsupported::PlatformProxy;
+    }
+}
 
 pub struct SysProxyManager;
 

--- a/src/commands/network/sys_proxy/mod.rs
+++ b/src/commands/network/sys_proxy/mod.rs
@@ -12,6 +12,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "linux")] {
         mod linux;
         use linux::PlatformProxy;
+    } else if #[cfg(target_os = "macos")] {
+        mod macos;
+        use macos::PlatformProxy;
     } else {
         mod unsupported;
         use unsupported::PlatformProxy;

--- a/src/commands/network/sys_proxy/mod.rs
+++ b/src/commands/network/sys_proxy/mod.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+
+pub struct SysProxyStatus {
+    pub enabled: bool,
+    pub proxy_port: Option<u16>,
+}
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+use windows::PlatformProxy;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use linux::PlatformProxy;
+
+pub struct SysProxyManager;
+
+impl SysProxyManager {
+    pub fn get() -> Result<SysProxyStatus> {
+        PlatformProxy::get()
+    }
+
+    pub fn set(status: SysProxyStatus) -> Result<()> {
+        PlatformProxy::set(status)
+    }
+
+    pub fn clear() -> Result<()> {
+        PlatformProxy::clear()
+    }
+}

--- a/src/commands/network/sys_proxy/unsupported.rs
+++ b/src/commands/network/sys_proxy/unsupported.rs
@@ -1,0 +1,23 @@
+use anyhow::{bail, Result};
+
+use crate::println_warn;
+use super::SysProxyStatus;
+
+pub struct PlatformProxy;
+
+impl PlatformProxy {
+    pub fn get() -> Result<SysProxyStatus> {
+        println_warn!("Current platform is not supported, operation is invalid");
+        bail!("unsupported platform")
+    }
+
+    pub fn set(_status: SysProxyStatus) -> Result<()> {
+        println_warn!("Current platform is not supported, operation is invalid");
+        bail!("unsupported platform")
+    }
+
+    pub fn clear() -> Result<()> {
+        println_warn!("Current platform is not supported, operation is invalid");
+        bail!("unsupported platform")
+    }
+}

--- a/src/commands/network/sys_proxy/windows.rs
+++ b/src/commands/network/sys_proxy/windows.rs
@@ -1,0 +1,163 @@
+use anyhow::{Context, Result};
+use winreg::enums::{
+    HKEY_CURRENT_USER,
+    KEY_READ,
+    KEY_WRITE,
+};
+use winreg::RegKey;
+
+use super::SysProxyStatus;
+
+
+pub struct PlatformProxy;
+
+
+const PROXY_REG_PATH: &str =
+    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
+
+
+
+impl PlatformProxy {
+
+    /// 获取当前系统代理状态
+    pub fn get() -> Result<SysProxyStatus> {
+
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+
+        let settings = hkcu
+            .open_subkey_with_flags(
+                PROXY_REG_PATH,
+                KEY_READ
+            )
+            .context(
+                "Failed to open Internet Settings registry key"
+            )?;
+
+
+        let enabled: u32 = settings
+            .get_value("ProxyEnable")
+            .unwrap_or(0);
+
+
+        let proxy_server: String = settings
+            .get_value("ProxyServer")
+            .unwrap_or_default();
+
+
+        Ok(SysProxyStatus {
+            enabled: enabled != 0,
+            proxy_port: parse_port(&proxy_server),
+        })
+    }
+
+
+
+    /// 设置系统代理
+    pub fn set(status: SysProxyStatus) -> Result<()> {
+
+        let port = status
+            .proxy_port
+            .unwrap_or(7890);
+
+
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+
+        let settings = hkcu
+            .open_subkey_with_flags(
+                PROXY_REG_PATH,
+                KEY_WRITE
+            )
+            .context(
+                "Failed to open Internet Settings registry key"
+            )?;
+
+
+        let proxy = format!(
+            "127.0.0.1:{port}"
+        );
+
+
+        settings
+            .set_value(
+                "ProxyEnable",
+                &1u32
+            )
+            .context(
+                "Failed to enable proxy"
+            )?;
+
+
+        settings
+            .set_value(
+                "ProxyServer",
+                &proxy
+            )
+            .context(
+                "Failed to set ProxyServer"
+            )?;
+
+
+        settings
+            .set_value(
+                "ProxyOverride",
+                &"localhost;127.0.0.1;<local>"
+            )
+            .context(
+                "Failed to set ProxyOverride"
+            )?;
+
+        Ok(())
+    }
+
+
+
+    /// 禁用系统代理
+    pub fn clear() -> Result<()> {
+
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+
+        let settings = hkcu
+            .open_subkey_with_flags(
+                PROXY_REG_PATH,
+                KEY_WRITE
+            )
+            .context(
+                "Failed to open Internet Settings registry key"
+            )?;
+
+
+        settings
+            .set_value(
+                "ProxyEnable",
+                &0u32
+            )
+            .context(
+                "Failed to disable proxy"
+            )?;
+            
+        Ok(())
+    }
+}
+
+/// 从 ProxyServer 中解析端口
+fn parse_port(server: &str) -> Option<u16> {
+
+    let first = server
+        .split(';')
+        .next()?;
+
+
+    let addr = first
+        .split('=')
+        .last()?;
+
+
+    addr
+        .rsplit(':')
+        .next()?
+        .parse()
+        .ok()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clap::{CommandFactory, Parser};
 
 use crate::{
     arguments::Args,
-    commands::{config, connection, control, inspect, profile, proxy, rule, rule_set},
+    commands::{config, connection, control, inspect, network, profile, proxy, rule, rule_set},
 };
 
 #[tokio::main]
@@ -31,6 +31,7 @@ async fn run() -> Result<()> {
         Args::Proxy(args) => proxy::handle_proxy(args).await?,
         Args::Rule => rule::print_rule().await?,
         Args::RuleSet(args) => rule_set::handle_rule_set(args).await?,
+        Args::Network(args) => network::handle_network(args).await?,
         Args::ShellCompletion { shell } => {
             let mut cmd = Args::command();
             let bin_name = cmd.get_name().to_owned();


### PR DESCRIPTION
增加了network subcommand，目前实现了proxy的开关。

对于windows，代理设置直接写入系统注册表。
对于Linux和MacOS，会在mihomosh的配置文件目录下生成proxy.sh，让用户自己在.bashrc中source。

增加的业务逻辑文件都在src/command/network里。
遵循了Mihomosh用完就关的原则，对项目架构没有调整。但是系统代理这种系统级别的东西兼容性确实不太好，我不确定这是不是该项目想要的，要不要merge就完全up to you了：）我用着反正挺开心。

后续我可能把Tun开关也加进来。